### PR TITLE
feat/leave-module

### DIFF
--- a/app/Http/Controllers/Api/PayrollController.php
+++ b/app/Http/Controllers/Api/PayrollController.php
@@ -22,7 +22,7 @@ class PayrollController extends Controller
             return response()->json([
                 'message' => 'no record',
                 'data' => $payroll
-            ], 200);
+            ], 404);
         }
 
         return response()->json([

--- a/app/Http/Controllers/AttendanceController.php
+++ b/app/Http/Controllers/AttendanceController.php
@@ -9,6 +9,7 @@ use App\Models\DailyPayrollLog;
 use App\Models\Employee;
 use App\Models\Company;
 use App\Models\EmployeeSchedule;
+use App\Services\Payroll\PayrollHistory;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
@@ -18,6 +19,7 @@ class AttendanceController extends Controller
 {
     public function __construct(
         protected AttendanceReport $report,
+        protected PayrollHistory $payslip,
     ){}
 
     public function showAttendance($id)
@@ -507,6 +509,8 @@ class AttendanceController extends Controller
                     $attendanceDate,
                     $request->company_id
                 );
+
+                $this->payslip->generatePayslipReference();
             } catch (\Exception $e) {
                 \Log::error('Payroll sync failed in manual attendance modal', [
                     'employee_id' => $request->employee_id,

--- a/app/Http/Requests/AdminRegisterPersonal.php
+++ b/app/Http/Requests/AdminRegisterPersonal.php
@@ -20,6 +20,7 @@ class AdminRegisterPersonal extends FormRequest
             'last_name' => ['required','string','max:255'],
             'suffix' => [ 'nullable', 'in:Sr.,Jr.,Other'],
             'email' => ['required','email','unique:admins,email'],
+            'website' => 'prohibited',
             'password' => [
                 'required',
                 'string',

--- a/app/Mail/AnnouncementMail.php
+++ b/app/Mail/AnnouncementMail.php
@@ -32,7 +32,7 @@ class AnnouncementMail extends Mailable
 
     public function build()
     {
-        return $this->from('autopayroll@autopayroll.org', 'Autopayroll System')
+        return $this->from('info@autopayroll.org', 'Autopayroll System')
             ->subject($this->announcement->title)
             ->view('emails.announcement');
     }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,9 @@ namespace App\Providers;
 
 use App\Models\Employee;
 use App\Observers\EmployeeObserver;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -21,6 +24,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-//        Employee::observe(EmployeeObserver::class);
+        RateLimiter::for('register-attempts', function (Request $request) {
+            return Limit::perMinute(5)->by($request->ip());
+        });
     }
 }

--- a/app/Services/Auth/AdminRegistration.php
+++ b/app/Services/Auth/AdminRegistration.php
@@ -5,6 +5,7 @@ use App\Models\Admin;
 use App\Services\GenerateId;
 use App\Services\Payroll\PayrollPeriodService;
 use Illuminate\Auth\Events\Registered;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 
 class AdminRegistration
@@ -36,21 +37,31 @@ class AdminRegistration
     public function createAdmin(array $data): Admin
     {
         $personal = session('register.personal');
-        $data = array_merge($personal, $data);
-        $data['password'] = Hash::make($data['password']);
-        $data['profile_photo'] = 'profile-photos/default_profile.jpg';
-        $data['admin_id'] = $this->generateId->generateId(Admin::class, 'admin_id');
 
+        // Safety check: if session expired, redirect back
+        if (!$personal) {
+            throw new \Exception("Registration session expired.");
+        }
 
-        $admin = Admin::create($data);
+        $combinedData = array_merge($personal, $data);
+        $combinedData['password'] = Hash::make($combinedData['password']);
+        $combinedData['profile_photo'] = 'profile-photos/default_profile.jpg';
+        $combinedData['admin_id'] = $this->generateId->generateId(Admin::class, 'admin_id');
 
-        $this->periodService->createPeriod($data['admin_id']);
+        // Wrap in a transaction
+        return DB::transaction(function () use ($combinedData) {
+            $admin = Admin::create($combinedData);
 
-        event(new Registered($admin));
+            // If this fails, the whole block throws an exception and rolls back
+            $this->periodService->createPeriod($combinedData['admin_id']);
 
-        session()->forget('register.personal');
+            // Fire event ONLY if DB operations succeeded
+            event(new Registered($admin));
 
-        return $admin;
+            session()->forget('register.personal');
+
+            return $admin;
+        });
     }
 
 }

--- a/resources/views/auth/admin-register-step1.blade.php
+++ b/resources/views/auth/admin-register-step1.blade.php
@@ -24,6 +24,7 @@
             <form action="{{route('auth.store.step1')}}" method="post">
                 @csrf
 {{--                first name--}}
+                <input type="text" name="website" style="display:none;">
                 <div class="field-row">
                   <x-form-input
                     label="First Name"

--- a/routes/web.php
+++ b/routes/web.php
@@ -37,15 +37,16 @@ Route::get('/', function () {
     return view('welcome');
 });
 /**admin registration*/
-Route::get('/register/admin/credentials', [AdminRegistrationController::class, 'showStep1'])
-    ->name('auth.register.step1');
-Route::get('/register/admin/address', [AdminRegistrationController::class, 'showStep2'])
-    ->name('auth.register.step2');
+Route::middleware(['throttle:register-attempts'])->group(function () {
 Route::post('/register/admin/success', [AdminRegistrationController::class, 'register'])
     ->name('admin.register');
 Route::post('/register/admin/personal-info', [AdminRegistrationController::class, 'storeStep1'])
     ->name('auth.store.step1');
-
+});
+Route::get('/register/admin/credentials', [AdminRegistrationController::class, 'showStep1'])
+    ->name('auth.register.step1');
+Route::get('/register/admin/address', [AdminRegistrationController::class, 'showStep2'])
+    ->name('auth.register.step2');
 
 //login
 Route::get('/login', function () {


### PR DESCRIPTION
## Summary by Sourcery

Add safety, security, and rate limiting improvements across admin registration, attendance, and payroll flows.

New Features:
- Wrap admin registration in a database transaction with session-expiry guarding to ensure atomic user and payroll period creation.
- Introduce rate limiting for admin registration-related POST routes using a dedicated throttle configuration.
- Trigger payslip reference generation after successful manual attendance save operations.

Bug Fixes:
- Return HTTP 404 instead of 200 when payroll records are not found in the payroll API response.

Enhancements:
- Update default sender email for announcement emails to use the info@autopayroll.org address.
- Block misuse of the hidden honeypot website field during admin registration to reduce bot signups.